### PR TITLE
generic role removal

### DIFF
--- a/bin/cleanclaudia.sh
+++ b/bin/cleanclaudia.sh
@@ -9,37 +9,21 @@ usage() {
 
 #Initialization of variables
 roleName="alexa-icloudtools-executor"
-kmsRolePolicy="kms-access-json"
-logRolePolicy="log-writer"
-
 
 #Clean up Claudia
 echo "***  Attempting to delete existing roles,policies, and aliases..(may see errors)."
 
-rolepolicyexist=$(aws iam list-role-policies --role-name "$roleName" | grep "$kmsRolePolicy") >/dev/null 2>&1
-if [ -z "$rolepolicyexist" ]; then
- echo "No role policies to delete\n"
-else
- aws iam delete-role-policy --role-name "$roleName" --policy-name "$kmsRolePolicy"
- echo "$roleName policy has been removed"
-fi
-
-rolepolicyexist=$(aws iam list-role-policies --role-name "$roleName" | grep "$logRolePolicy") >/dev/null 2>&1
-if [ -z "$rolepolicyexist" ]; then
- echo "No role policies to delete\n"
-else
- aws iam delete-role-policy --role-name "$roleName" --policy-name "$logRolePolicy"
- echo "$roleName policy has been removed"
-fi
-
-# Delete main role (used for Claudia)
-roleexists=$( aws iam list-roles | grep "role/$roleName\""  ) 2>&1
-if [ -z "$roleexists" ]; then
- echo "No roles to delete"
-else
-aws iam delete-role --role-name "$roleName"
-echo "$roleName role has been removed"
-fi
+roles=$(aws iam list-roles --query 'Roles[?RoleName==`'$roleName'`].RoleName' --output text)
+for role in $roles; do
+  echo deleting policies for role $role
+  policies=$(aws iam list-role-policies --role-name=$role --query PolicyNames --output text)
+  for policy in $policies; do 
+    echo deleting policy $policy for role $role
+    aws iam delete-role-policy --policy-name $policy --role-name $role
+  done
+  echo deleting role $role
+  aws iam delete-role --role-name $role
+done
 
 aws lambda delete-function --function-name alexa-icloudtools
 


### PR DESCRIPTION
this checks if the role actually exists before removal, and removes all policies attached to the role, instead of just the two named policies. should enable you to add more policies later easier. check out https://github.com/claudiajs/claudia/blob/master/spec/clean-test-resources.sh for some hints how to cycle through other objects if you need that later